### PR TITLE
added support for logmech

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 ## dbt-teradata 0.19.0 (TBD)
+
+* Added support for LOGMECH authentication parameter. With LOGMECH support, the adapter can now authenticate using LDAP, Kerberes, TDNEGO and the database native protocol.

--- a/dbt/adapters/teradata/connections.py
+++ b/dbt/adapters/teradata/connections.py
@@ -21,6 +21,7 @@ class TeradataCredentials(Credentials):
     username: Optional[str]
     password: Optional[str]
     tmode: Optional[str]
+    logmech: Optional[str]
     charset: Optional[str]
 
     _ALIASES = {
@@ -65,6 +66,7 @@ class TeradataCredentials(Credentials):
             "schema",
             "user",
             "tmode",
+            "logmech"
         )
 
 
@@ -97,6 +99,9 @@ class TeradataConnectionManager(SQLConnectionManager):
         kwargs["user"] = credentials.username
         kwargs["password"] = credentials.password
         kwargs["tmode"] = credentials.tmode
+        if credentials.logmech:
+            kwargs["logmech"] = credentials.logmech
+
 
         # Save the transaction mode
         cls.TMODE = credentials.tmode


### PR DESCRIPTION
### Description

This PR adds support for LOGMECH authentication option. This option allows users to authenticate with dbt using LDAP, TDNEGO, Kerberos and DB native mechanisms.

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
