### PR TITLE
make create relationship macros work with and without ctes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dbt-integration-tests
 test/integration/.user.yml
 .DS_Store
 .vscode
+.editorconfig

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,5 @@
 
 * Fixed `teradata__create_table_as` and `teradata__create_view_as` macros to accommodate models with CTE's and without CTE's.
 * Added support for LOGMECH authentication parameter. With LOGMECH support, the adapter can now authenticate using LDAP, Kerberes, TDNEGO and the database native protocol.
+* Eliminated the need for `dbt_drop_relation_if_exists` stored procedure
+* Implemented `teradata__create_schema` and `teradata__drop_schema` macros

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 ## dbt-teradata 0.19.0 (TBD)
+
+* Fixed `teradata__create_table_as` and `teradata__create_view_as` macros to accommodate models with CTE's and without CTE's.

--- a/dbt/adapters/teradata/impl.py
+++ b/dbt/adapters/teradata/impl.py
@@ -146,18 +146,6 @@ class TeradataAdapter(SQLAdapter):
         exists = True if schema in [row[0] for row in results] else False
         return exists
 
-    def create_schema(self, relation: BaseRelation):
-        """Create the given schema if it does not exist."""
-        raise dbt.exceptions.NotImplementedException(
-            f'`create_schema` is not implemented for this adapter. Contact your Teradata administator to `create database {relation.without_identifier()} ...;`'
-        )
-
-    def drop_schema(self, relation: BaseRelation):
-        """Drop the given schema (and everything in it) if it exists."""
-        raise dbt.exceptions.NotImplementedException(
-            f'`drop_schema` is not implemented for this adapter. Contact your Teradata administator to `drop database {relation.without_identifier()};`'
-        )
-
     # Methods used in adapter tests
     def update_column_sql(
         self,

--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -10,7 +10,7 @@
 
 {% macro teradata__drop_relation(relation) -%}
     {% call statement('drop_relation', auto_begin=False) -%}
-        call {{ relation.schema }}.dbt_drop_relation_if_exists('{{ relation.type }}', '{{ relation }}');
+        DROP {{ relation.type }} /*+ IF EXISTS */ {{ relation }};
     {%- endcall %}
 {% endmacro %}
 
@@ -63,7 +63,7 @@
     2. Rename the new relation to the existing relation
   #}
   {% call statement('drop_relation') %}
-    call {{ to_relation.schema }}.dbt_drop_relation_if_exists('{{ to_relation.type }}', '{{ to_relation }}');
+    DROP {{ to_relation.type }} /*+ IF EXISTS */ {{ to_relation }};
   {% endcall %}
   {% call statement('rename_relation') %}
     rename {{ to_relation.type }} {{ from_relation }} to {{ to_relation }}
@@ -177,3 +177,28 @@
 {% macro teradata__generate_database_name(custom_database_name=none, node=none) -%}
   {% do return(None) %}
 {%- endmacro %}
+
+{% macro teradata__create_schema(relation) -%}
+  {% if relation.database -%}
+    {{ adapter.verify_database(relation.database) }}
+  {%- endif -%}
+  {%- call statement('create_schema') -%}
+    CREATE DATABASE {{ relation.without_identifier().include(database=False) }}
+    -- Teradata expects db sizing params on creation. This macro is probably
+    -- useful only for testing. For production scenrios, a properly sized
+    -- database (schema) will likely exist before dbt gets called
+    AS PERMANENT = 60e6, -- 60MB
+        SPOOL = 120e6; -- 120MB
+  {%- endcall -%}
+{% endmacro %}
+
+{% macro teradata__drop_schema(relation) -%}
+  {% if relation.database -%}
+    {{ adapter.verify_database(relation.database) }}
+    {%- call statement('drop_schema') -%}
+    DELETE DATABASE {{ relation.without_identifier().include(database=False) }};
+    DROP DATABASE {{ relation.without_identifier().include(database=False) }};
+  {%- endcall -%}
+  {%- endif -%}
+
+{% endmacro %}

--- a/dbt/include/teradata/macros/adapters.sql
+++ b/dbt/include/teradata/macros/adapters.sql
@@ -24,21 +24,32 @@
   {%- set sql_header = config.get('sql_header', none) -%}
 
   {{ sql_header if sql_header is not none }}
-  create table
+
+  {% if sql.strip().upper().startswith('WITH') %}
+    create table
     {{ relation.include(database=False) }}
-  as (
-    {{ sql }}
-  )
-  with data
+    as (
+      SELECT * FROM (
+        {{ sql }}
+      ) D
+    ) with data
+  {% else %}
+    create table
+    {{ relation.include(database=False) }}
+    as (
+        {{ sql }}
+      ) with data
+  {% endif %}
+
 {% endmacro %}
 
 {% macro teradata__create_view_as(relation, sql) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
 
   {{ sql_header if sql_header is not none }}
-  replace view {{ relation.include(database=False) }} as (
+  replace view {{ relation.include(database=False) }} as
     {{ sql }}
-  )
+
 {% endmacro %}
 
 {% macro teradata__current_timestamp() -%}

--- a/test/README.md
+++ b/test/README.md
@@ -23,10 +23,6 @@ Use one of the following methods to setup a test server:
 - [Run Vantage Express on VirtualBox](https://quickstarts.teradata.com/docs/17.10/getting.started.vbox.html)
 - [Run Vantage Express on VMware](https://quickstarts.teradata.com/docs/17.10/getting.started.vmware.html)
 
-### Setup Test database
-Manually run this SQL script in your database (edit it first if the user has a different name than `dbc`):
-- `script/test_setup.sql`
-
 ### Install test dependencies
 ```shell
 python3 -m venv env
@@ -61,23 +57,3 @@ Some tests that are expected to fail are commented out within this file:
 - `test/integration/teradata-17.10.dbtspec`
 
 Un-comment to test new functionality being added.
-
-### Troubleshooting
-
-`dbt/adapters/teradata/impl.py` contains the following Python class method definitions:
-- `create_schema`
-- `drop_schema`
-
-Alternatively, these definitions can be removed and replaced with Jinja macro definitions within `dbt/include/teradata/macros/adapters.sql`:
-- `teradata__create_schema`
-- `teradata__drop_schema`
-
-Currently, none of these are implemented. In order to pass the integration tests, this code within `impl.py` needs to be commented out:
-```python
-   def drop_schema(self, relation: BaseRelation):
-       """Drop the given schema (and everything in it) if it exists."""
-       # raise dbt.exceptions.NotImplementedException(
-       #     f'`drop_schema` is not implemented for this adapter. Contact your Teradata administrator to `drop database {relation.without_identifier()};`'
-       # )
-       pass
-```

--- a/test/integration/teradata-17.10.dbtspec
+++ b/test/integration/teradata-17.10.dbtspec
@@ -7,6 +7,178 @@ target:
   schema: dbt_test
   tmode: ANSI
 
+projects:
+  - name: validate_teradata_cases
+    paths:
+      models/table_with_cte.sql: |
+        {{
+            config(
+                materialized='table'
+            )
+        }}
+        WITH
+        source_a as (
+            select 1 as a1, 2 as a2
+        ),
+        source_b as (
+            select 1 as b1, 2 as b2
+        )
+        SELECT * FROM source_a, source_b
+
+      models/table_without_cte.sql: |
+        {{
+            config(
+                materialized='table'
+            )
+        }}
+        SELECT  1 as a1, 2 as a2, 1 as b1, 2 as b2
+
+      models/view_with_cte.sql: |
+        {{
+            config(
+                materialized='view'
+            )
+        }}
+        WITH
+        source_a as (
+            select 1 as a1, 2 as a2
+        ),
+        source_b as (
+            select 1 as b1, 2 as b2
+        )
+        SELECT * FROM source_a, source_b
+
+      models/view_without_cte.sql: |
+        {{
+            config(
+                materialized='view'
+            )
+        }}
+        WITH
+        source_a as (
+            select 1 as a1, 2 as a2
+        ),
+        source_b as (
+            select 1 as b1, 2 as b2
+        )
+        SELECT * FROM source_a, source_b
+
+      models/table_with_cte_comments.sql: |
+              {{
+                  config(
+                      materialized='table'
+                  )
+              }}
+              -- This is a test comment
+              WITH
+              source_a as (
+                  select 1 as a1, 2 as a2
+              ),
+              source_b as (
+                  select 1 as b1, 2 as b2
+              )
+              SELECT * FROM source_a, source_b
+
+      models/schema.yaml: |
+        version: 2
+        models:
+          - name: table_with_cte
+            columns:
+            - name: a1
+              tests:
+                - not_null
+            - name: a2
+              tests:
+                - not_null
+            - name: b1
+              tests:
+                - not_null
+            - name: b2
+              tests:
+                - not_null
+          - name: table_without_cte
+            columns:
+            - name: a1
+              tests:
+                - not_null
+            - name: a2
+              tests:
+                - not_null
+            - name: b1
+              tests:
+                - not_null
+            - name: b2
+              tests:
+                - not_null
+          - name: view_with_cte
+            columns:
+            - name: a1
+              tests:
+                - not_null
+            - name: a2
+              tests:
+                - not_null
+            - name: b1
+              tests:
+                - not_null
+            - name: b2
+              tests:
+                - not_null
+          - name: view_without_cte
+            columns:
+            - name: a1
+              tests:
+                - not_null
+            - name: a2
+              tests:
+                - not_null
+            - name: b1
+              tests:
+                - not_null
+            - name: b2
+              tests:
+                - not_null
+    facts:
+      run:
+        length: 5
+        names:
+            - table_with_cte
+            - table_without_cte
+            - view_with_cte
+            - view_without_cte
+            - table_with_cte_comments
+      persisted_relations:
+          - table_with_cte
+          - table_without_cte
+          - view_with_cte
+          - view_without_cte
+          - table_with_cte_comments
+      table_with_cte:
+          rowcount: 1
+      table_without_cte:
+          rowcount: 1
+      view_with_cte:
+          rowcount: 1
+      view_without_cte:
+          rowcount: 1
+      expected_types_view:
+          table_with_cte: table
+          table_without_cte: table
+          view_with_cte: view
+          view_without_cte: view
+          table_with_cte_comments: table
+      expected_types_table:
+          table_with_cte: table
+          table_without_cte: table
+          view_with_cte: view
+          view_without_cte: view
+          table_with_cte_comments: table
+      catalog:
+          nodes:
+              length: 5
+          sources:
+              length: 0
+
 sequences:
 
   # List of sequences:
@@ -18,6 +190,40 @@ sequences:
   test_dbt_ephemeral: ephemeral
   test_dbt_data_test: data_test
   test_dbt_schema_test: schema_test
+  test_dbt_teradata:
+    project: validate_teradata_cases
+    sequence:
+      - type: dbt
+        cmd: run
+      - type: run_results
+        exists: True
+      - type: run_results
+        length: fact.run.length
+      - type: relation_types
+        expect: fact.expected_types_table
+      - type: relation_rows
+        name: table_with_cte
+        length: fact.table_with_cte.rowcount
+      - type: relation_rows
+        name: table_without_cte
+        length: fact.table_without_cte.rowcount
+      - type: relation_rows
+        name: view_with_cte
+        length: fact.view_with_cte.rowcount
+      - type: relation_rows
+        name: view_without_cte
+        length: fact.view_without_cte.rowcount
+      - type: relations_equal
+        relations: fact.persisted_relations
+      - type: dbt
+        cmd: docs generate
+      - type: catalog
+        exists: True
+        nodes:
+          length: fact.catalog.nodes.length
+        sources:
+          length: fact.catalog.sources.length
+
 
   # FAIL
   # test_dbt_incremental: incremental


### PR DESCRIPTION
resolves #

This PR resolves an issue where the adapter could not materialize tables and views with CTE and without CTE.

### Description

The PR changes `teradata__create_table_as` and `teradata__create_view_as` macros to accommodate models with CTE's and without CTE's.


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
