### PR TITLE
Enforce the max batch size of 2536

### DIFF
--- a/dbt/include/teradata/macros/materializations/seed/seed.sql
+++ b/dbt/include/teradata/macros/materializations/seed/seed.sql
@@ -1,5 +1,12 @@
 
+{% macro teradata__get_batch_size() %}
+    {{ return(2536) }}
+{% endmacro %}
+
 {% macro basic_load_csv_rows(model, batch_size, agate_table) %}
+
+    {% set max_batch_size = teradata__get_batch_size() %}
+    {% set batch_size = [batch_size, max_batch_size]|min %}
     {% set cols_sql = get_seed_column_quoted_csv(model, agate_table.column_names) %}
     {% set bindings = [] %}
 


### PR DESCRIPTION
resolves #4

### Description

Allow the batch size to be specified, but use a value no larger than the Teradata max of 2536.

### Checklist
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
