### PR TITLE
Randomize db name in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Incremental materialization ([#16](https://github.com/dbeatty10/dbt-teradata/issues/16), [#17](https://github.com/dbeatty10/dbt-teradata/pull/17))
 * Eliminated the need for `dbt_drop_relation_if_exists` stored procedure ([#5](https://github.com/dbeatty10/dbt-teradata/pull/5)
 * Implemented `teradata__create_schema` and `teradata__drop_schema` macros ([#5](https://github.com/dbeatty10/dbt-teradata/pull/5)
+* Introduced randomized database name in tests
 
 ### Fixes
 * Enforce the max batch size of 2536 for seeds ([#4](https://github.com/dbeatty10/dbt-teradata/issues/4), [#11](https://github.com/dbeatty10/dbt-teradata/pull/11))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 * Incremental materialization ([#16](https://github.com/dbeatty10/dbt-teradata/issues/16), [#17](https://github.com/dbeatty10/dbt-teradata/pull/17))
 * Eliminated the need for `dbt_drop_relation_if_exists` stored procedure ([#5](https://github.com/dbeatty10/dbt-teradata/pull/5)
 * Implemented `teradata__create_schema` and `teradata__drop_schema` macros ([#5](https://github.com/dbeatty10/dbt-teradata/pull/5)
-* Introduced randomized database name in tests
 
 ### Fixes
 * Enforce the max batch size of 2536 for seeds ([#4](https://github.com/dbeatty10/dbt-teradata/issues/4), [#11](https://github.com/dbeatty10/dbt-teradata/pull/11))
@@ -19,3 +18,4 @@
 ### Under the hood
 * pytest-dbt-adapter integration tests ([#6](https://github.com/dbeatty10/dbt-teradata/issues/6), [#8](https://github.com/dbeatty10/dbt-teradata/pull/8))
 * Integration tests in GitHub Actions ([#10](https://github.com/dbeatty10/dbt-teradata/issues/10), [#19](https://github.com/dbeatty10/dbt-teradata/pull/19), [#24](https://github.com/dbeatty10/dbt-teradata/issues/24), [#23](https://github.com/dbeatty10/dbt-teradata/pull/23))
+* Introduced randomized database name in tests

--- a/test/integration/teradata-17.10.dbtspec
+++ b/test/integration/teradata-17.10.dbtspec
@@ -4,7 +4,7 @@ target:
   server: "{{ env_var('DBT_TERADATA_SERVER_NAME', 'localhost') }}"
   username: "{{ env_var('DBT_TERADATA_USERNAME', 'dbc') }}"
   password: "{{ env_var('DBT_TERADATA_PASSWORD', 'dbc') }}"
-  schema: dbt_test
+  schema: "dbt_test_{{ var('_dbt_random_suffix') }}"
   tmode: ANSI
 
 projects:


### PR DESCRIPTION
### Description

This PR randomizes the db name in pytest. It's a recommended practice by pytest creators. It also resolves an issue with `test_dbt_incremental` test which is not idempotent. The tests runs cleanly only during the first run on a database. Subsequent runs fail as row counts do not match. The db name randomization makes sure that pytest creates a new database for each test run. pytest will also take care of destroying the database.


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
