### PR TITLE
Add support for fastload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Incremental materialization ([#16](https://github.com/dbeatty10/dbt-teradata/issues/16), [#17](https://github.com/dbeatty10/dbt-teradata/pull/17))
 * Eliminated the need for `dbt_drop_relation_if_exists` stored procedure ([#5](https://github.com/dbeatty10/dbt-teradata/pull/5)
 * Implemented `teradata__create_schema` and `teradata__drop_schema` macros ([#5](https://github.com/dbeatty10/dbt-teradata/pull/5)
+* Added support for `fastload` mode for `dbt seed` command([#27](https://github.com/dbeatty10/dbt-teradata/pull/27)) 
 
 ### Fixes
 * Enforce the max batch size of 2536 for seeds ([#4](https://github.com/dbeatty10/dbt-teradata/issues/4), [#11](https://github.com/dbeatty10/dbt-teradata/pull/11))

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ my-teradata-db-profile:
 
 All, apart from `source` and `snapshot`.
 
+### Custom configurations
+
+#### Seeds
+
+* `use_fastload` configuration will instruct the plugin to use [fastload](https://github.com/Teradata/python-driver#FastLoad) when handling `dbt seed` command. You can set this seed configuration option in your `project.yml` file, e.g.:
+    ```yaml
+    seeds:
+      <project-name>:
+        +use_fastload: true
+    ```
+
 ## Limitations
 
 ### Connection configuration

--- a/test/integration/teradata-17.10.dbtspec
+++ b/test/integration/teradata-17.10.dbtspec
@@ -178,6 +178,23 @@ projects:
               length: 5
           sources:
               length: 0
+  - name: validate_teradata_fastload
+    paths:
+      data/test_table.csv: |
+        id,attrA,attrB
+        1,val1A,val1B
+        2,val2A,val2B
+        3,val3A,val3B
+        4,val4A,val4B
+
+    dbt_project_yml:
+      seeds:
+        +use_fastload: true
+    facts:
+      run:
+        length: 1
+      test_table:
+        rowcount: 4
 
 sequences:
 
@@ -223,6 +240,18 @@ sequences:
           length: fact.catalog.nodes.length
         sources:
           length: fact.catalog.sources.length
+  test_dbt_teradata_fastload:
+    project: validate_teradata_fastload
+    sequence:
+      - type: dbt
+        cmd: seed
+      - type: run_results
+        exists: True
+      - type: run_results
+        length: fact.run.length
+      - type: relation_rows
+        name: test_table
+        length: fact.test_table.rowcount
 
   # FAIL
   # test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp


### PR DESCRIPTION
resolves #21

### Description

The PR adds a custom configuration option for seeds called `use_fastload`. When this config is set to `true`, the plugin will use [fastload](https://github.com/Teradata/python-driver#FastLoad) to load the data. I've tested it with larger files. In one test, I used a csv file with > 1M records. The file size was ~20 MB's. Without fastload, the load time was 3 minutes. With fastload, the load time was less than 30 seconds. This was done on my local against a Vantage Express VM which has 2 AMPs. Real Teradata clusters have many more AMPs.

The PR also improves performance for regular seed loads without fastload. It replaces multiple inserts per batch with a single insert per batch fed with a 2-dimensional binding array. This seems to work much faster with the Teradata wire protocol.

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
