### PR TITLE
Support for dbt sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Incremental materialization ([#16](https://github.com/dbeatty10/dbt-teradata/issues/16), [#17](https://github.com/dbeatty10/dbt-teradata/pull/17))
 * Eliminated the need for `dbt_drop_relation_if_exists` stored procedure ([#5](https://github.com/dbeatty10/dbt-teradata/pull/5)
 * Implemented `teradata__create_schema` and `teradata__drop_schema` macros ([#5](https://github.com/dbeatty10/dbt-teradata/pull/5)
+* Added support for dbt sources ([#29](https://github.com/dbeatty10/dbt-teradata/pull/29))
 
 ### Fixes
 * Enforce the max batch size of 2536 for seeds ([#4](https://github.com/dbeatty10/dbt-teradata/issues/4), [#11](https://github.com/dbeatty10/dbt-teradata/pull/11))

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ my-teradata-db-profile:
 
 ### Commands
 
-All, apart from `source` and `snapshot`.
+All dbt commands are supported.
 
 ## Limitations
 

--- a/dbt/adapters/teradata/relation.py
+++ b/dbt/adapters/teradata/relation.py
@@ -23,11 +23,6 @@ class TeradataRelation(BaseRelation):
     include_policy: TeradataIncludePolicy = TeradataIncludePolicy()
     quote_character: str = '"'
 
-    def __post_init__(self):
-
-        if self.database != self.schema and self.database:
-            raise RuntimeException(f'Cannot set database {self.database} in teradata!')
-
     def render(self):
         if self.include_policy.database and self.include_policy.schema:
             raise RuntimeException(

--- a/test/integration/teradata-17.10.dbtspec
+++ b/test/integration/teradata-17.10.dbtspec
@@ -178,7 +178,34 @@ projects:
               length: 5
           sources:
               length: 0
+  - name: validate_teradata_sources
+    paths:
+      data/test_table.csv: |
+        id,attrA,attrB
+        1,val1A,val1B
+        2,val2A,val2B
+        3,val3A,val3B
+        4,val4A,val4B
 
+      models/table_from_source.sql: |
+        SELECT * FROM {{ source('alias_source_schema', 'alias_source_table') }}
+
+      models/sources.yml: |
+        version: 2
+        sources:
+          - name: alias_source_schema
+            schema: dbt_test
+            tables:
+              - name: alias_source_table
+                identifier: test_table
+
+    facts:
+      run:
+        length: 1
+      test_table:
+        rowcount: 4
+      table_from_source:
+        rowcount: 4
 sequences:
 
   # List of sequences:
@@ -223,7 +250,27 @@ sequences:
           length: fact.catalog.nodes.length
         sources:
           length: fact.catalog.sources.length
-
+  test_dbt_teradata_sources:
+    project: validate_teradata_sources
+    sequence:
+      - type: dbt
+        cmd: seed
+      - type: run_results
+        exists: True
+      - type: run_results
+        length: fact.run.length
+      - type: relation_rows
+        name: test_table
+        length: fact.test_table.rowcount
+      - type: dbt
+        cmd: run
+      - type: run_results
+        exists: True
+      - type: run_results
+        length: fact.run.length
+      - type: relation_rows
+        name: table_from_source
+        length: fact.table_from_source.rowcount
   # FAIL
   # test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
   # test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols

--- a/test/integration/teradata-17.10.dbtspec
+++ b/test/integration/teradata-17.10.dbtspec
@@ -194,7 +194,7 @@ projects:
         version: 2
         sources:
           - name: alias_source_schema
-            schema: dbt_test
+            schema: "{{ target.schema }}"
             tables:
               - name: alias_source_table
                 identifier: test_table


### PR DESCRIPTION
### Description

This PR adds support for dbt sources. In fact, all I did is removed `def __post_init__(self)` method from `TeradataRelation` class in `relation.py`. I couldn't think of a reason why this check would be required and it was the only thing that was messing with sources functionality. The PR also contains new tests for dbt sources.

Since this PR touches the same files as previous pending PRs, there will be some merge conflicts. They should be easy to resolve though.

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
